### PR TITLE
Add user subscription checks in pre-screening page

### DIFF
--- a/pages/event/[eventSlug]/pre-screening/index.vue
+++ b/pages/event/[eventSlug]/pre-screening/index.vue
@@ -41,12 +41,6 @@ const userStore = useUserStore();
 
 const eventSlug = route.params.eventSlug as string;
 
-// 1) Fast path: usa o cache local
-if (userStore.hasSubscriptionInEvent(eventSlug)) {
-  navigateTo(`/event/${eventSlug}/ticket`);
-}
-
-// 2) Check definitivo: busca no backend se necessário
 const existing = await userStore.getSubscription(eventSlug);
 if (existing) {
   navigateTo(`/event/${eventSlug}/ticket`);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The pre-screening page now automatically checks if you already have a subscription for the event and, if so, takes you directly to your ticket page (/event/{eventSlug}/ticket). This streamlines access for returning users by skipping unnecessary steps.
  - If no subscription is found, the pre-screening flow continues as before, with existing navigation behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->