### PR TITLE
fix(auth): authenticate from URL token to survive Safari cookie blocking

### DIFF
--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -3,7 +3,11 @@ import type { LocationQuery } from "#vue-router";
 export default defineNuxtRouteMiddleware(async (to, from) => {
   if (process.server) return;
 
-  const isLoggedIn = await evaluateCurrentLogin(from.query);
+  // O token chega na URL de destino (to.query) no retorno do login. Lemos
+  // to.query primeiro e mantemos from.query como rede de segurança, em vez de
+  // depender só do cookie .hemocione.com.br (que o Safari/ITP segura no
+  // primeiro hit cross-subdomínio).
+  const isLoggedIn = await evaluateCurrentLogin({ ...from.query, ...to.query });
   if (!isLoggedIn) {
     redirectToID(to.fullPath);
     return;
@@ -60,8 +64,9 @@ export async function evaluateCurrentLogin(query?: LocationQuery) {
 }
 
 export function getCurrentToken(query?: LocationQuery): string | null {
-  if (query?.token) {
-    return String(query.token);
+  const queryToken = normalizeQueryToken(query?.token);
+  if (queryToken) {
+    return queryToken;
   }
 
   const { token } = useUserStore();
@@ -72,6 +77,21 @@ export function getCurrentToken(query?: LocationQuery): string | null {
   const config = useRuntimeConfig();
   const cookieToken = useCookie(config.public.authCookieKey).value as string;
   return cookieToken;
+}
+
+// A URL pode chegar com mais de um `token`: o hemocione-id faz append do token
+// recém-emitido numa URL que já carregava o token do goToCanDonate, e o
+// vue-router transforma isso num array. Pega o último valor não-vazio, que é o
+// mais recente.
+function normalizeQueryToken(
+  token: LocationQuery[string] | undefined,
+): string | null {
+  if (token == null) return null;
+  if (Array.isArray(token)) {
+    const last = token.filter(Boolean).pop();
+    return last ? String(last) : null;
+  }
+  return String(token);
 }
 
 export function redirectToID(fullPath: string) {


### PR DESCRIPTION
## Problema

No Safari, o login durante a inscrição num evento pode degradar a auth ao voltar pro evento, contribuindo pro usuário cair no fluxo on-demand do posso-doar em vez do fluxo de evento.

## Causa

`middleware/auth.ts` autenticava lendo `from.query` (vazio na entrada externa) + cookie `.hemocione.com.br`. O token JWT chega em **`to.query`** no retorno do login. Dependendo do cookie cross-subdomínio, o **Safari/ITP** segura o cookie no primeiro hit e a auth falha.

## Fix

- Autentica por `to.query` primeiro (`from.query` mantido como rede de segurança).
- `normalizeQueryToken`: trata `token` duplicado que o hemocione-id pode anexar (vue-router vira array → token inválido).

Pareado com o can-donate: Hemocione/hemocione-can-donate#33 (mesma branch). O fix central do bug relatado está no can-donate; este alinha o digital-event ao mesmo padrão de auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)