### PR TITLE
fix(event): treat subscription 401 as logged-out instead of blocking page

### DIFF
--- a/stores/user.ts
+++ b/stores/user.ts
@@ -121,7 +121,12 @@ export const useUserStore = defineStore("user", {
         this.subscriptions.set(eventSlug, subscription);
         return subscription;
       } catch (err: any) {
-        if (err?.data?.statusCode === 404) {
+        const statusCode = err?.data?.statusCode ?? err?.statusCode;
+
+        // 404 = sem subscription; 401 = sem token ou token inválido/expirado.
+        // Em ambos os casos tratamos como "não inscrito / deslogado" e seguimos
+        // sem subscription, em vez de propagar o erro e travar a página.
+        if (statusCode === 404 || statusCode === 401) {
           return null;
         }
 


### PR DESCRIPTION
## Problema

Ao acessar a página pública de um evento (ex.: `/event/vitta-residencial-yvr4`), a tela trava com erro por causa de um **401** numa das APIs que chamamos.

## Causa raiz

- `components/Events/Footer.vue:33` faz `await userStore.getSubscription(eventSlug)` no topo do `<script setup>` (bloqueante).
- `getSubscription` (`stores/user.ts`) tratava só **404** como "sem subscription" (`null`) e **re-lançava** qualquer outro erro — incluindo **401**.
- O endpoint `/api/v1/event/[slug]/subscription/mine` retorna **401 "Invalid Token"** quando recebe um token ausente/expirado (`useHemocioneUserAuth`). Confirmado via `curl` na prod.
- `fetchWithAuth` lê o token do cookie `.hemocione.com.br` (e, desde o fix do Safari, da URL) **sem validar**. Um usuário recorrente com token expirado no cookie dispara a chamada com token stale → 401 → erro re-lançado no setup async → **tela travada**.
- Usuário totalmente anônimo (sem token) não é afetado: `fetchWithAuth` retorna `null` antes de chamar.

## Fix

Tratar **401 igual a 404** em `getSubscription`: retornar `null` (sem subscription / deslogado), para o footer renderizar os botões de deslogado em vez de propagar o erro.

Mudança mínima e segura — todos os call sites de `getSubscription` já tratam `null` (tipo `Promise<Subscription | null>`). As demais páginas que chamam `getSubscription` usam o middleware `auth` (redirecionam pro login), então só a página pública de evento chegava nesse caminho com cookie stale.

## Verificação

- `curl` confirma o 401 do endpoint com token inválido.
- Preview deploy da Vercel: reproduzir com cookie `hemocioneId` stale e confirmar que a página renderiza (não trava).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced subscription status verification to properly handle authentication failures, ensuring the app correctly identifies when users are not logged in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->