### PR TITLE
feat(backoffice): listar inscrições de um evento

### DIFF
--- a/server/api/v1/event/[eventSlug]/subscription/index.get.ts
+++ b/server/api/v1/event/[eventSlug]/subscription/index.get.ts
@@ -1,0 +1,54 @@
+import { assertSecretAuth } from "~/server/services/auth";
+import { getEventBySlug } from "~/server/services/event";
+import { listEventSubscriptions } from "~/server/services/subscription";
+
+const TAKE_PADRAO = 100;
+const TAKE_MAXIMO = 500;
+
+function lerInteiro(
+  valor: unknown,
+  padrao: number,
+  minimo: number,
+  maximo: number,
+) {
+  if (valor === undefined || valor === "") return padrao;
+
+  const numero = Number(valor);
+  if (!Number.isInteger(numero)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Invalid pagination",
+    });
+  }
+
+  return Math.min(Math.max(numero, minimo), maximo);
+}
+
+/**
+ * Lista as inscricoes de um evento.
+ *
+ * So havia as rotas "mine", do proprio usuario: quem opera um evento
+ * presencial nao tinha como conferir quem se inscreveu em cada horario sem
+ * consultar o banco na mao.
+ */
+export default defineEventHandler(async (event) => {
+  assertSecretAuth(event);
+
+  const eventSlug = String(getRouterParam(event, "eventSlug"));
+
+  const foundEvent = await getEventBySlug(eventSlug);
+  if (!foundEvent) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Event not found",
+    });
+  }
+
+  const query = getQuery(event);
+
+  return await listEventSubscriptions(eventSlug, {
+    ...(query.scheduleId ? { scheduleId: String(query.scheduleId) } : {}),
+    take: lerInteiro(query.take, TAKE_PADRAO, 1, TAKE_MAXIMO),
+    skip: lerInteiro(query.skip, 0, 0, Number.MAX_SAFE_INTEGER),
+  });
+});

--- a/server/api/v1/event/[eventSlug]/subscription/index.get.ts
+++ b/server/api/v1/event/[eventSlug]/subscription/index.get.ts
@@ -1,3 +1,4 @@
+import { Types } from "mongoose";
 import { assertSecretAuth } from "~/server/services/auth";
 import { getEventBySlug } from "~/server/services/event";
 import { listEventSubscriptions } from "~/server/services/subscription";
@@ -46,8 +47,18 @@ export default defineEventHandler(async (event) => {
 
   const query = getQuery(event);
 
+  // `schedule._id` e um ObjectId. Um valor malformado chega ao Mongoose e vira
+  // CastError, ou seja, 500 para o que e erro de quem chamou.
+  const scheduleId = query.scheduleId ? String(query.scheduleId) : undefined;
+  if (scheduleId !== undefined && !Types.ObjectId.isValid(scheduleId)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Invalid scheduleId",
+    });
+  }
+
   return await listEventSubscriptions(eventSlug, {
-    ...(query.scheduleId ? { scheduleId: String(query.scheduleId) } : {}),
+    ...(scheduleId ? { scheduleId } : {}),
     take: lerInteiro(query.take, TAKE_PADRAO, 1, TAKE_MAXIMO),
     skip: lerInteiro(query.skip, 0, 0, Number.MAX_SAFE_INTEGER),
   });

--- a/server/services/subscription.ts
+++ b/server/services/subscription.ts
@@ -36,6 +36,49 @@ export function getEventSubscriptions(eventSlug: string) {
     .lean();
 }
 
+/**
+ * Lista paginada das inscricoes de um evento, para uso do backoffice.
+ *
+ * Separada de `getEventSubscriptions` de proposito: aquela e consumida pelo
+ * cron que computa doacoes do evento e precisa do conjunto inteiro, sem
+ * paginacao. Mudar a assinatura dela para atender aqui quebraria o cron.
+ */
+export async function listEventSubscriptions(
+  eventSlug: string,
+  options: { scheduleId?: string; take: number; skip: number },
+) {
+  const { scheduleId, take, skip } = options;
+  const filter = {
+    eventSlug,
+    deletedAt: null,
+    ...(scheduleId ? { "schedule._id": scheduleId } : {}),
+  };
+
+  // A contagem usa o mesmo filtro da pagina: quem opera o evento precisa saber
+  // quantas inscricoes existem, nao so quantas vieram nesta pagina.
+  const [total, items] = await Promise.all([
+    Subscription.countDocuments(filter),
+    Subscription.find(filter)
+      .select({
+        hemocioneId: 1,
+        eventSlug: 1,
+        name: 1,
+        email: 1,
+        phone: 1,
+        document: 1,
+        code: 1,
+        schedule: 1,
+        createdAt: 1,
+      })
+      .sort({ "schedule.startAt": 1, createdAt: 1 })
+      .skip(skip)
+      .limit(take)
+      .lean(),
+  ]);
+
+  return { total, items };
+}
+
 export type UserSubscriptions = Awaited<
   ReturnType<typeof getUserSubscriptions>
 >;


### PR DESCRIPTION
## Por quê

Surgiu ao construir o [hemocione-mcp](https://github.com/Hemocione/hemocione-mcp), um proxy MCP dos endpoints de backoffice. Ao catalogar as rotas de evento ficou claro que **não existe como listar as inscrições de um evento**: só há as rotas `mine`, do próprio usuário. Quem opera um evento presencial não tem como conferir quem se inscreveu em cada horário sem consultar o Mongo na mão.

O service já existia — `getEventSubscriptions` — mas era consumido apenas pelo cron do Inngest que computa as doações do evento; nenhuma rota HTTP o expunha.

## O que entra

`GET /api/v1/event/:eventSlug/subscription`, protegido por `assertSecretAuth` como as demais rotas de backoffice de evento:

- filtro opcional `scheduleId`, para ver as inscrições de um horário específico;
- paginação `take` (padrão 100, teto 500) e `skip`, com 400 em valor não-inteiro;
- resposta `{ total, items }`, em que `total` usa **o mesmo filtro** da página — quem opera precisa saber quantas inscrições existem, não quantas vieram nesta página;
- ordenação por horário e depois por criação, que é a ordem em que a operação lê a lista;
- 404 quando o evento não existe.

### Por que uma função nova em vez de estender a existente

`listEventSubscriptions` é separada de `getEventSubscriptions` de propósito: a segunda é usada por `server/inngest/eventHandlers/computeEventDonations.ts`, que precisa do conjunto **inteiro**, sem paginação. Mudar a assinatura dela para atender esta rota quebraria o cron silenciosamente. O call site do cron segue intocado.

## Verificação

`vue-tsc --noEmit` no repo acusa 36 erros de tipo, **todos pré-existentes** (páginas `.vue`, `stores/`, `server/errorHandler.ts`, e um dentro de `node_modules/nuxt-posthog`). Nenhum no arquivo novo nem dentro do bloco adicionado em `subscription.ts`:

```
$ npx vue-tsc --noEmit 2>&1 | grep "subscription/index.get.ts"
(vazio)
# erros em services/subscription.ts: linhas 150 e 153, dentro de createSubscription
# (eram as linhas 108 e 110 em origin/develop — deslocadas pelas 42 linhas acrescentadas)
```

`prettier --check` acusa `server/services/subscription.ts`, mas o drift é **anterior** a este PR: a versão de `origin/develop` também falha, e o único ajuste pedido é na linha 150, dentro de `createSubscription`. Deixei intocado para não misturar reformatação de código alheio no diff.

O build completo não pôde ser rodado localmente porque `nuxt-bugsnag` exige `BUGSNAG_API_KEY` e tenta subir sourcemap (401 com chave falsa) — o CI cobre isso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint for listing event subscriptions.
  * Added pagination, offset, and optional schedule filtering.
  * Results include subscription and schedule details, ordered by schedule start time and creation date.
  * Unknown events return a clear not-found response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->