### PR TITLE
fix(charts): validar a query do dataset em vez de responder 500

### DIFF
--- a/server/api/v1/charts/dataset.ts
+++ b/server/api/v1/charts/dataset.ts
@@ -1,24 +1,85 @@
 import _ from "lodash";
-import { getDatasets, type DatasetType } from "~/server/services/charts";
+import {
+  datasetTypes,
+  getDatasets,
+  type DatasetType,
+} from "~/server/services/charts";
+
+/**
+ * Datasets agregados de fila para os graficos operacionais.
+ *
+ * Os cinco parametros de query sao obrigatorios, mas nenhum era validado: sem
+ * `startedAt`/`endedAt`, `new Date(undefined).toISOString()` lancava RangeError;
+ * sem `datasets`, `undefined.split(",")` lancava TypeError. Nos dois casos a
+ * resposta saia 500. A guarda que existia (`if (!queueIds)`) era codigo morto,
+ * porque `_.castArray(undefined)` devolve `[undefined]`, que e truthy.
+ */
+function lerData(valor: unknown, nome: string): string {
+  if (typeof valor !== "string" || valor.trim() === "") {
+    throw createError({ statusCode: 400, statusMessage: `Missing ${nome}` });
+  }
+
+  const data = new Date(valor);
+  if (Number.isNaN(data.getTime())) {
+    throw createError({ statusCode: 400, statusMessage: `Invalid ${nome}` });
+  }
+
+  return data.toISOString();
+}
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
-  const queueIds = _.castArray(query.queueIds);
-  const startedAt = new Date(query.startedAt as string).toISOString();
-  const endedAt = new Date(query.endedAt as string).toISOString();
-  const intervalMin = Number(query.intervalMin);
-  const selectedDatasets = (query.datasets as string).split(
-    ",",
-  ) as DatasetType[];
 
-  if (!queueIds) {
-    throw new Error("queueIds is required");
+  const queueIds = _.castArray(query.queueIds)
+    .filter((id): id is string => typeof id === "string" && id.trim() !== "")
+    .map((id) => id.trim());
+
+  if (queueIds.length === 0) {
+    throw createError({ statusCode: 400, statusMessage: "Missing queueIds" });
   }
 
-  const datasets = await getDatasets(queueIds, selectedDatasets, {
+  const startedAt = lerData(query.startedAt, "startedAt");
+  const endedAt = lerData(query.endedAt, "endedAt");
+
+  if (new Date(endedAt) <= new Date(startedAt)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "endedAt must be after startedAt",
+    });
+  }
+
+  const intervalMin = Number(query.intervalMin);
+  // Intervalo zero ou negativo faria o laco que monta os intervalos em
+  // getDatasets nunca avancar.
+  if (!Number.isInteger(intervalMin) || intervalMin <= 0) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Invalid intervalMin",
+    });
+  }
+
+  if (typeof query.datasets !== "string" || query.datasets.trim() === "") {
+    throw createError({ statusCode: 400, statusMessage: "Missing datasets" });
+  }
+
+  const selectedDatasets = query.datasets
+    .split(",")
+    .map((tipo) => tipo.trim())
+    .filter(Boolean);
+
+  const invalido = selectedDatasets.find(
+    (tipo) => !datasetTypes.includes(tipo as DatasetType),
+  );
+  if (invalido || selectedDatasets.length === 0) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `Invalid datasets. Use: ${datasetTypes.join(", ")}`,
+    });
+  }
+
+  return await getDatasets(queueIds, selectedDatasets as DatasetType[], {
     startedAt,
     endedAt,
     intervalMin,
   });
-  return datasets;
 });

--- a/server/services/charts.ts
+++ b/server/services/charts.ts
@@ -1,7 +1,7 @@
 import dayjs from "dayjs";
 import { getCalledQueueParticipants } from "./queueParticipants";
 
-const datasetTypes = ["line", "candlestick"] as const;
+export const datasetTypes = ["line", "candlestick"] as const;
 export type DatasetType = (typeof datasetTypes)[number];
 interface CandlestickSet {
   timestamp: string;


### PR DESCRIPTION
## Por quê

Apareceu ao validar o [hemocione-mcp](https://github.com/Hemocione/hemocione-mcp) contra dev: `GET /api/v1/charts/dataset` era a única tool que continuava respondendo 500. Investigando, o motivo não era o parâmetro que eu mandei — a rota responde **500 até sem nenhum parâmetro**.

```
$ curl -s -o /dev/null -w '%{http_code}' 'https://eventos.d.hemocione.com.br/api/v1/charts/dataset'
500
```

## O que estava errado

A rota exige cinco parâmetros de query e não validava nenhum:

| Parâmetro ausente | O que acontecia |
|---|---|
| `startedAt` / `endedAt` | `new Date(undefined).toISOString()` lança `RangeError: Invalid time value` → 500 |
| `datasets` | `(query.datasets as string).split(",")` com `undefined` → `TypeError` → 500 |
| `queueIds` | A guarda passava batido — ver abaixo |

A única guarda existente era **código morto**:

```ts
const queueIds = _.castArray(query.queueIds);
if (!queueIds) {                      // nunca dispara
  throw new Error("queueIds is required");
}
```

`_.castArray(undefined)` devolve `[undefined]` — um array de um elemento, portanto truthy. A condição jamais era verdadeira, e `queueIds` chegava a `getDatasets` como `[undefined]`.

## O que muda

Cada parâmetro passa a ser validado com `createError({ statusCode: 400 })` e uma mensagem do que falta:

- `queueIds` — descarta entradas vazias e exige pelo menos um id;
- `startedAt` / `endedAt` — exige data parseável, e `endedAt` depois de `startedAt`;
- `intervalMin` — exige inteiro **positivo**: zero ou negativo faria o laço que monta os intervalos em `getDatasets` nunca avançar;
- `datasets` — valida os tipos contra a lista real (`line`, `candlestick`), que passou a ser exportada de `server/services/charts.ts`.

O contrato aceito é exatamente o que `pages/chart/line-and-candlestick.vue` já envia — nenhuma chamada existente muda de comportamento, só as malformadas passam de 500 para 400.

## Verificação

`vue-tsc --noEmit` mantém o mesmo baseline de 36 erros pré-existentes do repo, nenhum nos dois arquivos deste PR:

```
$ npx vue-tsc --noEmit 2>&1 | grep -E "charts/dataset|services/charts"
(vazio)
$ npx vue-tsc --noEmit 2>&1 | grep -c "error TS"
36
```

`prettier --check` passa nos dois arquivos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)