### PR TITLE
fix(event): invalidar o cache no update e no delete por slug

### DIFF
--- a/server/services/event.ts
+++ b/server/services/event.ts
@@ -260,7 +260,7 @@ export async function getEventBySlug(
 }
 
 export async function deleteEventBySlug(eventSlug: string) {
-  return await Event.findOneAndUpdate(
+  const event = await Event.findOneAndUpdate(
     {
       slug: eventSlug,
     },
@@ -271,6 +271,11 @@ export async function deleteEventBySlug(eventSlug: string) {
       lean: true,
     },
   );
+
+  // Sem invalidar, o cache segue servindo o evento como ativo ate o TTL, e o
+  // evento desativado continua alcancavel por slug depois de deletado.
+  removeEventFromCache(eventSlug);
+  return event;
 }
 
 export async function updateEventBySlug(
@@ -281,7 +286,11 @@ export async function updateEventBySlug(
   if (!event) return null;
 
   event.set({ ...data, queue: { ...event.queue, ...data.queue } });
-  return (await event.save()).toObject();
+  const saved = (await event.save()).toObject();
+
+  // Sem invalidar, uma leitura seguinte devolve o evento anterior a edicao.
+  removeEventFromCache(eventSlug);
+  return saved;
 }
 
 export async function createEvent(data: CreateEventDTO) {


### PR DESCRIPTION
## Como apareceu

Exercitando o ciclo criar → editar → deletar de um evento pelo [hemocione-mcp](https://github.com/Hemocione/hemocione-mcp) contra dev, dois passos não bateram:

```
3. atualizar_evento (PUT)          -> 200, corpo já com "TESTE MCP - renomeado"
4. obter_evento (GET seguinte)     -> nome: "TESTE MCP - apagar"      ← antigo

7. deletar_evento (DELETE)         -> HTTP 204
8. obter_evento (GET seguinte)     -> 200, evento ainda presente      ← deletado
```

Confirmado direto no upstream, sem o proxy no caminho: o evento sai das listagens (`/api/v1/event` e `?old=true`) mas o `GET /api/v1/event/{slug}` segue devolvendo 200.

## Causa

`getEventBySlug` guarda o resultado em `currentEventsBySlugCache`, com `MAX_CURRENT_EVENTS_CACHE_TTL` de 1 minuto. Das seis funções de escrita do service, **quatro** invalidam com `removeEventFromCache` e duas não:

| Função | Invalidava? |
|---|---|
| `incrementEventExternalVolunteersOccupiedSlots` | ✅ |
| `incrementEventScheduleOccupiedSlots` | ✅ |
| `enableEventSubscription` | ✅ |
| `updateEventScheduleSlots` | ✅ |
| `updateEventBySlug` | ❌ |
| `deleteEventBySlug` | ❌ |

As duas que faltavam são exatamente editar e deletar — as que mais mudam o que o usuário vê.

## Impacto

Janela de até 1 minuto, **por instância**. Na Vercel isso deixa o sintoma intermitente: a leitura obsoleta depende de qual instância atende a requisição, e uma instância que nunca cacheou aquele slug responde certo. Na prática:

- um evento editado no backoffice continua sendo mostrado com os dados antigos;
- um evento **cancelado** continua acessível pela URL, e a pessoa pode abrir a página de um evento que não existe mais.

## O que muda

Duas chamadas de `removeEventFromCache`, alinhando as duas funções com as outras quatro. `deleteEventBySlug` passa a guardar o retorno para invalidar antes de devolver — o valor retornado é o mesmo de antes.

## Verificação

`vue-tsc --noEmit` mantém o baseline de 36 erros pré-existentes do repo, nenhum em `server/services/event.ts`:

```
$ npx vue-tsc --noEmit 2>&1 | grep "services/event.ts"
(vazio)
$ npx vue-tsc --noEmit 2>&1 | grep -c "error TS"
36
```

`prettier --check` acusa `event.ts`, mas o drift é anterior a este PR (a versão de `origin/develop` também falha) e está nas linhas 238 e 397 — nenhuma delas tocada aqui. Deixei intocado para não misturar reformatação alheia no diff.

Validação de comportamento vem no preview: o ciclo do MCP repetido contra ele deve mostrar o PUT e o DELETE refletindo na leitura seguinte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event updates and deletions now reliably persist changes and refresh cached event data.
  * Updated event details are returned immediately after modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->