### PR TITLE
fix(event): invalidar o cache no default_schedules e no markDonationsAsSent

### DIFF
--- a/server/services/event.ts
+++ b/server/services/event.ts
@@ -328,6 +328,10 @@ export async function setEventDefaultSchedule(
   const subscription = { schedules };
   event.set({ subscription });
   const hemoEvent = await event.save();
+
+  // Sem invalidar, a leitura seguinte devolve o evento sem os horarios que
+  // acabaram de ser gerados.
+  removeEventFromCache(eventSlug);
   return hemoEvent.toObject();
 }
 
@@ -443,7 +447,7 @@ export function getEventsBySlugs(eventSlugs: string[]) {
 }
 
 export async function markDonationsAsSent(eventSlug: string) {
-  return await Event.findOneAndUpdate(
+  const event = await Event.findOneAndUpdate(
     {
       slug: eventSlug,
     },
@@ -454,6 +458,12 @@ export async function markDonationsAsSent(eventSlug: string) {
       lean: true,
     },
   );
+
+  // donationsSentAt e a guarda de idempotencia do cron de doacoes, e o cron a
+  // le por getEventBySlug. Sem invalidar, uma segunda execucao dentro do TTL
+  // le donationsSentAt vazio do cache e reenvia as doacoes do evento.
+  removeEventFromCache(eventSlug);
+  return event;
 }
 
 export async function getPointsOndeDoar(oldEvents: boolean = false) {


### PR DESCRIPTION
Complementa o #43, que ficou **incompleto por erro meu**: levantei os write paths com um grep por prefixo de nome (`update|delete|increment|enable|create`) e por isso não vi duas funções que também escrevem no `Event`. Refeita a auditoria sem viés de prefixo — procurando as chamadas de escrita em si — apareceram estas duas.

## Auditoria completa

| Função que escreve | Invalidava antes do #43 | Depois do #43 | Depois deste PR |
|---|---|---|---|
| `incrementEventExternalVolunteersOccupiedSlots` | ✅ | ✅ | ✅ |
| `incrementEventScheduleOccupiedSlots` | ✅ | ✅ | ✅ |
| `enableEventSubscription` | ✅ | ✅ | ✅ |
| `updateEventScheduleSlots` | ✅ | ✅ | ✅ |
| `updateEventBySlug` | ❌ | ✅ | ✅ |
| `deleteEventBySlug` | ❌ | ✅ | ✅ |
| `setEventDefaultSchedule` | ❌ | ❌ | ✅ |
| `markDonationsAsSent` | ❌ | ❌ | ✅ |
| `createEvent` | ❌ | ❌ | ❌ (correto) |

`createEvent` fica de fora de propósito: o evento é novo, não existe entrada de cache para aquele slug.

## `setEventDefaultSchedule`

Observado ao exercitar o ciclo pelo [hemocione-mcp](https://github.com/Hemocione/hemocione-mcp) contra dev:

```
4. gerar_horarios_padrao  isError=False      ← salvou no banco
6. horarios no evento     0                  ← leitura seguinte, do cache
```

Os horários estavam gravados; a leitura é que vinha do cache anterior à geração.

## `markDonationsAsSent` — o caso que mais me preocupa

`donationsSentAt` é a **guarda de idempotência** do cron que envia as doações do evento para o `hemocione-id`. E o próprio cron a lê por `getEventBySlug`, que é cacheado:

```ts
// server/inngest/eventHandlers/computeEventDonations.ts
const foundEvent = await getEventBySlug(slug);
if (!foundEvent || foundEvent.donationsSentAt) {
  return;                       // guarda
}
// ... computa e envia as doações ...
await markDonationsAsSent(slug); // grava a guarda, sem invalidar o cache
```

A guarda é lida de um cache que a escrita não invalidava. Uma segunda execução dentro do TTL de 1 minuto — retry do Inngest, evento duplicado, duas invocações concorrentes — lê `donationsSentAt` vazio, passa da guarda e **reenvia as doações do evento**.

Não reproduzi isso em dev (exigiria disparar o cron duas vezes na janela), então trato como risco identificado por leitura do código, não como bug observado. Mas o padrão é claro: invariante de idempotência lida de cache que a escrita não invalida.

## Verificação

`vue-tsc --noEmit` mantém o baseline de 36 erros pré-existentes, nenhum em `server/services/event.ts`. O `prettier --check` acusa o arquivo, mas nas linhas 238 e 401-407 — drift anterior, nenhuma delas minha (as linhas novas são ~318 e ~460).

🤖 Generated with [Claude Code](https://claude.com/claude-code)