### PR TITLE
release: listar inscrições + fixes de dataset e invalidação de cache

### DIFF
--- a/server/api/v1/charts/dataset.ts
+++ b/server/api/v1/charts/dataset.ts
@@ -1,24 +1,85 @@
 import _ from "lodash";
-import { getDatasets, type DatasetType } from "~/server/services/charts";
+import {
+  datasetTypes,
+  getDatasets,
+  type DatasetType,
+} from "~/server/services/charts";
+
+/**
+ * Datasets agregados de fila para os graficos operacionais.
+ *
+ * Os cinco parametros de query sao obrigatorios, mas nenhum era validado: sem
+ * `startedAt`/`endedAt`, `new Date(undefined).toISOString()` lancava RangeError;
+ * sem `datasets`, `undefined.split(",")` lancava TypeError. Nos dois casos a
+ * resposta saia 500. A guarda que existia (`if (!queueIds)`) era codigo morto,
+ * porque `_.castArray(undefined)` devolve `[undefined]`, que e truthy.
+ */
+function lerData(valor: unknown, nome: string): string {
+  if (typeof valor !== "string" || valor.trim() === "") {
+    throw createError({ statusCode: 400, statusMessage: `Missing ${nome}` });
+  }
+
+  const data = new Date(valor);
+  if (Number.isNaN(data.getTime())) {
+    throw createError({ statusCode: 400, statusMessage: `Invalid ${nome}` });
+  }
+
+  return data.toISOString();
+}
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
-  const queueIds = _.castArray(query.queueIds);
-  const startedAt = new Date(query.startedAt as string).toISOString();
-  const endedAt = new Date(query.endedAt as string).toISOString();
-  const intervalMin = Number(query.intervalMin);
-  const selectedDatasets = (query.datasets as string).split(
-    ",",
-  ) as DatasetType[];
 
-  if (!queueIds) {
-    throw new Error("queueIds is required");
+  const queueIds = _.castArray(query.queueIds)
+    .filter((id): id is string => typeof id === "string" && id.trim() !== "")
+    .map((id) => id.trim());
+
+  if (queueIds.length === 0) {
+    throw createError({ statusCode: 400, statusMessage: "Missing queueIds" });
   }
 
-  const datasets = await getDatasets(queueIds, selectedDatasets, {
+  const startedAt = lerData(query.startedAt, "startedAt");
+  const endedAt = lerData(query.endedAt, "endedAt");
+
+  if (new Date(endedAt) <= new Date(startedAt)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "endedAt must be after startedAt",
+    });
+  }
+
+  const intervalMin = Number(query.intervalMin);
+  // Intervalo zero ou negativo faria o laco que monta os intervalos em
+  // getDatasets nunca avancar.
+  if (!Number.isInteger(intervalMin) || intervalMin <= 0) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Invalid intervalMin",
+    });
+  }
+
+  if (typeof query.datasets !== "string" || query.datasets.trim() === "") {
+    throw createError({ statusCode: 400, statusMessage: "Missing datasets" });
+  }
+
+  const selectedDatasets = query.datasets
+    .split(",")
+    .map((tipo) => tipo.trim())
+    .filter(Boolean);
+
+  const invalido = selectedDatasets.find(
+    (tipo) => !datasetTypes.includes(tipo as DatasetType),
+  );
+  if (invalido || selectedDatasets.length === 0) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `Invalid datasets. Use: ${datasetTypes.join(", ")}`,
+    });
+  }
+
+  return await getDatasets(queueIds, selectedDatasets as DatasetType[], {
     startedAt,
     endedAt,
     intervalMin,
   });
-  return datasets;
 });

--- a/server/api/v1/event/[eventSlug]/subscription/index.get.ts
+++ b/server/api/v1/event/[eventSlug]/subscription/index.get.ts
@@ -1,0 +1,54 @@
+import { assertSecretAuth } from "~/server/services/auth";
+import { getEventBySlug } from "~/server/services/event";
+import { listEventSubscriptions } from "~/server/services/subscription";
+
+const TAKE_PADRAO = 100;
+const TAKE_MAXIMO = 500;
+
+function lerInteiro(
+  valor: unknown,
+  padrao: number,
+  minimo: number,
+  maximo: number,
+) {
+  if (valor === undefined || valor === "") return padrao;
+
+  const numero = Number(valor);
+  if (!Number.isInteger(numero)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Invalid pagination",
+    });
+  }
+
+  return Math.min(Math.max(numero, minimo), maximo);
+}
+
+/**
+ * Lista as inscricoes de um evento.
+ *
+ * So havia as rotas "mine", do proprio usuario: quem opera um evento
+ * presencial nao tinha como conferir quem se inscreveu em cada horario sem
+ * consultar o banco na mao.
+ */
+export default defineEventHandler(async (event) => {
+  assertSecretAuth(event);
+
+  const eventSlug = String(getRouterParam(event, "eventSlug"));
+
+  const foundEvent = await getEventBySlug(eventSlug);
+  if (!foundEvent) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Event not found",
+    });
+  }
+
+  const query = getQuery(event);
+
+  return await listEventSubscriptions(eventSlug, {
+    ...(query.scheduleId ? { scheduleId: String(query.scheduleId) } : {}),
+    take: lerInteiro(query.take, TAKE_PADRAO, 1, TAKE_MAXIMO),
+    skip: lerInteiro(query.skip, 0, 0, Number.MAX_SAFE_INTEGER),
+  });
+});

--- a/server/api/v1/event/[eventSlug]/subscription/index.get.ts
+++ b/server/api/v1/event/[eventSlug]/subscription/index.get.ts
@@ -1,3 +1,4 @@
+import { Types } from "mongoose";
 import { assertSecretAuth } from "~/server/services/auth";
 import { getEventBySlug } from "~/server/services/event";
 import { listEventSubscriptions } from "~/server/services/subscription";
@@ -46,8 +47,18 @@ export default defineEventHandler(async (event) => {
 
   const query = getQuery(event);
 
+  // `schedule._id` e um ObjectId. Um valor malformado chega ao Mongoose e vira
+  // CastError, ou seja, 500 para o que e erro de quem chamou.
+  const scheduleId = query.scheduleId ? String(query.scheduleId) : undefined;
+  if (scheduleId !== undefined && !Types.ObjectId.isValid(scheduleId)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Invalid scheduleId",
+    });
+  }
+
   return await listEventSubscriptions(eventSlug, {
-    ...(query.scheduleId ? { scheduleId: String(query.scheduleId) } : {}),
+    ...(scheduleId ? { scheduleId } : {}),
     take: lerInteiro(query.take, TAKE_PADRAO, 1, TAKE_MAXIMO),
     skip: lerInteiro(query.skip, 0, 0, Number.MAX_SAFE_INTEGER),
   });

--- a/server/services/charts.ts
+++ b/server/services/charts.ts
@@ -1,7 +1,7 @@
 import dayjs from "dayjs";
 import { getCalledQueueParticipants } from "./queueParticipants";
 
-const datasetTypes = ["line", "candlestick"] as const;
+export const datasetTypes = ["line", "candlestick"] as const;
 export type DatasetType = (typeof datasetTypes)[number];
 interface CandlestickSet {
   timestamp: string;

--- a/server/services/event.ts
+++ b/server/services/event.ts
@@ -260,7 +260,7 @@ export async function getEventBySlug(
 }
 
 export async function deleteEventBySlug(eventSlug: string) {
-  return await Event.findOneAndUpdate(
+  const event = await Event.findOneAndUpdate(
     {
       slug: eventSlug,
     },
@@ -271,6 +271,11 @@ export async function deleteEventBySlug(eventSlug: string) {
       lean: true,
     },
   );
+
+  // Sem invalidar, o cache segue servindo o evento como ativo ate o TTL, e o
+  // evento desativado continua alcancavel por slug depois de deletado.
+  removeEventFromCache(eventSlug);
+  return event;
 }
 
 export async function updateEventBySlug(
@@ -281,7 +286,11 @@ export async function updateEventBySlug(
   if (!event) return null;
 
   event.set({ ...data, queue: { ...event.queue, ...data.queue } });
-  return (await event.save()).toObject();
+  const saved = (await event.save()).toObject();
+
+  // Sem invalidar, uma leitura seguinte devolve o evento anterior a edicao.
+  removeEventFromCache(eventSlug);
+  return saved;
 }
 
 export async function createEvent(data: CreateEventDTO) {

--- a/server/services/event.ts
+++ b/server/services/event.ts
@@ -328,6 +328,10 @@ export async function setEventDefaultSchedule(
   const subscription = { schedules };
   event.set({ subscription });
   const hemoEvent = await event.save();
+
+  // Sem invalidar, a leitura seguinte devolve o evento sem os horarios que
+  // acabaram de ser gerados.
+  removeEventFromCache(eventSlug);
   return hemoEvent.toObject();
 }
 
@@ -443,7 +447,7 @@ export function getEventsBySlugs(eventSlugs: string[]) {
 }
 
 export async function markDonationsAsSent(eventSlug: string) {
-  return await Event.findOneAndUpdate(
+  const event = await Event.findOneAndUpdate(
     {
       slug: eventSlug,
     },
@@ -454,6 +458,12 @@ export async function markDonationsAsSent(eventSlug: string) {
       lean: true,
     },
   );
+
+  // donationsSentAt e a guarda de idempotencia do cron de doacoes, e o cron a
+  // le por getEventBySlug. Sem invalidar, uma segunda execucao dentro do TTL
+  // le donationsSentAt vazio do cache e reenvia as doacoes do evento.
+  removeEventFromCache(eventSlug);
+  return event;
 }
 
 export async function getPointsOndeDoar(oldEvents: boolean = false) {

--- a/server/services/subscription.ts
+++ b/server/services/subscription.ts
@@ -36,6 +36,49 @@ export function getEventSubscriptions(eventSlug: string) {
     .lean();
 }
 
+/**
+ * Lista paginada das inscricoes de um evento, para uso do backoffice.
+ *
+ * Separada de `getEventSubscriptions` de proposito: aquela e consumida pelo
+ * cron que computa doacoes do evento e precisa do conjunto inteiro, sem
+ * paginacao. Mudar a assinatura dela para atender aqui quebraria o cron.
+ */
+export async function listEventSubscriptions(
+  eventSlug: string,
+  options: { scheduleId?: string; take: number; skip: number },
+) {
+  const { scheduleId, take, skip } = options;
+  const filter = {
+    eventSlug,
+    deletedAt: null,
+    ...(scheduleId ? { "schedule._id": scheduleId } : {}),
+  };
+
+  // A contagem usa o mesmo filtro da pagina: quem opera o evento precisa saber
+  // quantas inscricoes existem, nao so quantas vieram nesta pagina.
+  const [total, items] = await Promise.all([
+    Subscription.countDocuments(filter),
+    Subscription.find(filter)
+      .select({
+        hemocioneId: 1,
+        eventSlug: 1,
+        name: 1,
+        email: 1,
+        phone: 1,
+        document: 1,
+        code: 1,
+        schedule: 1,
+        createdAt: 1,
+      })
+      .sort({ "schedule.startAt": 1, createdAt: 1 })
+      .skip(skip)
+      .limit(take)
+      .lean(),
+  ]);
+
+  return { total, items };
+}
+
 export type UserSubscriptions = Awaited<
   ReturnType<typeof getUserSubscriptions>
 >;


### PR DESCRIPTION
Promove para `main` o que já está validado em dev. São os PRs #41, #42, #43 e #44.

| O que vai | Por que importa |
|---|---|
| `GET /api/v1/event/:eventSlug/subscription` | Só havia as rotas `mine`. Quem opera um evento presencial não tinha como conferir quem se inscreveu em cada horário sem abrir o Mongo. |
| Validação da query de `/charts/dataset` | A rota exige cinco parâmetros e não validava nenhum: respondia **500 até sem parâmetro algum**. A guarda existente era código morto — `_.castArray(undefined)` devolve `[undefined]`, que é truthy. |
| Invalidação de cache em `updateEventBySlug` e `deleteEventBySlug` | `getEventBySlug` cacheia por 1 minuto e quatro das funções de escrita já invalidavam; editar e deletar não. O `PUT` respondia certo e a leitura seguinte trazia o dado antigo. |
| Invalidação em `setEventDefaultSchedule` e `markDonationsAsSent` | `donationsSentAt` é a **guarda de idempotência** do cron de doações, e o cron a lê por `getEventBySlug`. Sem invalidar, uma segunda execução na mesma janela lê a guarda vazia e **reenvia as doações do evento** para o hemocione-id. |

## Validação em dev

Exercitado pelo [hemocione-mcp](https://github.com/Hemocione/hemocione-mcp) contra `eventos.d.hemocione.com.br`: ciclo criar → editar → gerar horários → alterar horário → habilitar inscrições → deletar, provando que o `PUT` e o `default_schedules` passaram a refletir na leitura seguinte (antes não refletiam). Os casos de erro do `dataset` foram verificados um a um no preview (cada parâmetro ausente ou inválido → 400 com a mensagem certa; tudo válido → 200 com a série).

Uma ressalva registrada no #43: a invalidação é in-process, então **não elimina** leitura obsoleta entre instâncias da Vercel — provado deixando o TTL expirar. Reduz a janela e alinha os write paths; eliminar exigiria cache compartilhado.

## Nota

`main` tem 5 commits que `develop` não tem (fixes de Safari e de 401 na página de evento, mais o release). O merge preserva os dois lados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint for viewing event subscriptions with schedule filtering and pagination.
  * Improved chart dataset requests with clear validation for dates, intervals, queues, and supported dataset types.

* **Bug Fixes**
  * Prevented outdated event and donation information from being served from cache after updates.
  * Invalid requests now return clear client errors instead of causing runtime failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->