### PR TITLE
release: vínculo evento↔banco de sangue/instituição + gamification facts

### DIFF
--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -3,7 +3,11 @@ import type { LocationQuery } from "#vue-router";
 export default defineNuxtRouteMiddleware(async (to, from) => {
   if (process.server) return;
 
-  const isLoggedIn = await evaluateCurrentLogin(from.query);
+  // O token chega na URL de destino (to.query) no retorno do login. Lemos
+  // to.query primeiro e mantemos from.query como rede de segurança, em vez de
+  // depender só do cookie .hemocione.com.br (que o Safari/ITP segura no
+  // primeiro hit cross-subdomínio).
+  const isLoggedIn = await evaluateCurrentLogin({ ...from.query, ...to.query });
   if (!isLoggedIn) {
     redirectToID(to.fullPath);
     return;
@@ -60,8 +64,9 @@ export async function evaluateCurrentLogin(query?: LocationQuery) {
 }
 
 export function getCurrentToken(query?: LocationQuery): string | null {
-  if (query?.token) {
-    return String(query.token);
+  const queryToken = normalizeQueryToken(query?.token);
+  if (queryToken) {
+    return queryToken;
   }
 
   const { token } = useUserStore();
@@ -72,6 +77,21 @@ export function getCurrentToken(query?: LocationQuery): string | null {
   const config = useRuntimeConfig();
   const cookieToken = useCookie(config.public.authCookieKey).value as string;
   return cookieToken;
+}
+
+// A URL pode chegar com mais de um `token`: o hemocione-id faz append do token
+// recém-emitido numa URL que já carregava o token do goToCanDonate, e o
+// vue-router transforma isso num array. Pega o último valor não-vazio, que é o
+// mais recente.
+function normalizeQueryToken(
+  token: LocationQuery[string] | undefined,
+): string | null {
+  if (token == null) return null;
+  if (Array.isArray(token)) {
+    const last = token.filter(Boolean).pop();
+    return last ? String(last) : null;
+  }
+  return String(token);
 }
 
 export function redirectToID(fullPath: string) {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -66,6 +66,9 @@ export default defineNuxtConfig({
       process.env.HEMOCIONE_ID_JWT_SECRET_KEY ?? "secret",
     hemocioneIdIntegrationSecret:
       process.env.HEMOCIONE_ID_INTEGRATION_SECRET ?? "secret",
+    hemocioneIdApiUrl:
+      process.env.HEMOCIONE_ID_API_URL ?? "http://localhost:8080",
+    hemocioneIdFactsSecret: process.env.HEMOCIONE_ID_FACTS_SECRET ?? "secret",
     secret: process.env.API_SECRET ?? "secret",
     mongodbUri:
       process.env.MONGODB_URI ??

--- a/server/api/v1/event/[eventSlug]/index.put.ts
+++ b/server/api/v1/event/[eventSlug]/index.put.ts
@@ -42,6 +42,26 @@ function assertUpdateEventDTO(body: unknown): asserts body is UpdateEventDTO {
       });
     }
   }
+
+  if (
+    "bloodBanksLocationId" in body &&
+    (typeof body.bloodBanksLocationId !== "string" || !isUuid(body.bloodBanksLocationId))
+  ) {
+    throw createError({
+      statusCode: 422,
+      statusMessage: "Invalid bloodBanksLocationId",
+    });
+  }
+
+  if (
+    "institutionId" in body &&
+    (typeof body.institutionId !== "string" || !isUuid(body.institutionId))
+  ) {
+    throw createError({
+      statusCode: 422,
+      statusMessage: "Invalid institutionId",
+    });
+  }
 }
 
 export default defineEventHandler(async (event) => {

--- a/server/api/v1/event/index.post.ts
+++ b/server/api/v1/event/index.post.ts
@@ -63,6 +63,26 @@ function assertCreateEventDTO(body: any): asserts body is CreateEventDTO {
       });
     }
   }
+
+  if (
+    "bloodBanksLocationId" in body &&
+    (typeof body.bloodBanksLocationId !== "string" || !isUuid(body.bloodBanksLocationId))
+  ) {
+    throw createError({
+      statusCode: 422,
+      statusMessage: "Invalid bloodBanksLocationId",
+    });
+  }
+
+  if (
+    "institutionId" in body &&
+    (typeof body.institutionId !== "string" || !isUuid(body.institutionId))
+  ) {
+    throw createError({
+      statusCode: 422,
+      statusMessage: "Invalid institutionId",
+    });
+  }
 }
 
 export default defineEventHandler(async (event) => {

--- a/server/api/v1/internal/reconciliation/facts.get.ts
+++ b/server/api/v1/internal/reconciliation/facts.get.ts
@@ -1,0 +1,11 @@
+import { assertHemocioneIdIntegrationSecret } from "~/server/services/auth";
+import { getReconciliationFactsSince } from "~/server/services/factsReconciliationService";
+
+export default defineEventHandler(async (event) => {
+  assertHemocioneIdIntegrationSecret(event);
+
+  const since = String(getQuery(event).since ?? new Date(0).toISOString());
+  const facts = await getReconciliationFactsSince(new Date(since));
+
+  return { facts };
+});

--- a/server/models/event.ts
+++ b/server/models/event.ts
@@ -118,6 +118,16 @@ const EventSchema = new Schema(
       required: false,
       default: null,
     },
+    bloodBanksLocationId: {
+      type: String,
+      required: false,
+      default: null,
+    },
+    institutionId: {
+      type: String,
+      required: false,
+      default: null,
+    },
     subscription: {
       enabled: {
         type: Boolean,

--- a/server/services/attendanceFacts.ts
+++ b/server/services/attendanceFacts.ts
@@ -1,0 +1,24 @@
+import { postFactToHemocioneId } from "./hemocioneIdFacts";
+import { QueueParticipant } from "~/server/models/queueParticipant";
+
+export async function pushAttendanceConfirmedFacts(
+  participantIds: string[],
+  queueId: string,
+) {
+  const calledParticipants = await QueueParticipant.find({
+    _id: { $in: participantIds },
+  });
+
+  for (const participant of calledParticipants) {
+    const hemocioneId = participant.participant.hemocioneId;
+    if (!hemocioneId || !participant.calledAt) continue;
+
+    await postFactToHemocioneId({
+      userId: hemocioneId,
+      eventType: "event.attendance_confirmed",
+      occurredAt: participant.calledAt.toISOString(),
+      payload: { queueId },
+      idempotencyKey: `hemocione-digital-event:event.attendance_confirmed:${participant._id.toString()}`,
+    });
+  }
+}

--- a/server/services/event.ts
+++ b/server/services/event.ts
@@ -23,6 +23,8 @@ export interface CreateEventDTO {
   registerDonationUrl?: string;
   registerDonationDateLimit?: string;
   private?: boolean;
+  bloodBanksLocationId?: string;
+  institutionId?: string;
 }
 
 export interface UpdateEventDTO {
@@ -47,6 +49,8 @@ export interface UpdateEventDTO {
   registerDonationUrl?: string;
   registerDonationDateLimit?: string;
   private?: boolean;
+  bloodBanksLocationId?: string;
+  institutionId?: string;
 }
 
 export function getEventsForSync(data: {

--- a/server/services/factsReconciliationService.ts
+++ b/server/services/factsReconciliationService.ts
@@ -1,0 +1,26 @@
+import { QueueParticipant } from "~/server/models/queueParticipant";
+
+type Fact = {
+  userId: string;
+  eventType: string;
+  occurredAt: string;
+  payload: Record<string, unknown>;
+  idempotencyKey: string;
+};
+
+export const getReconciliationFactsSince = async (
+  since: Date,
+): Promise<Fact[]> => {
+  const calledParticipants = await QueueParticipant.find({
+    calledAt: { $ne: null, $gte: since },
+    "participant.hemocioneId": { $ne: null },
+  });
+
+  return calledParticipants.map((participant) => ({
+    userId: participant.participant.hemocioneId as string,
+    eventType: "event.attendance_confirmed",
+    occurredAt: (participant.calledAt as Date).toISOString(),
+    payload: { queueId: participant.queueId.toString() },
+    idempotencyKey: `hemocione-digital-event:event.attendance_confirmed:${participant._id.toString()}`,
+  }));
+};

--- a/server/services/hemocioneIdFacts.ts
+++ b/server/services/hemocioneIdFacts.ts
@@ -1,0 +1,32 @@
+const config = useRuntimeConfig();
+
+type GamificationFact = {
+  userId: string;
+  eventType: string;
+  occurredAt: string;
+  payload: Record<string, unknown>;
+  idempotencyKey: string;
+};
+
+// Deliberately catches internally — called via runAsync/waitUntil with no caller
+// awaiting the result, so a rejected promise here would only surface as an
+// unhandled rejection instead of failing anything meaningful.
+export async function postFactToHemocioneId(fact: GamificationFact) {
+  try {
+    const response = await fetch(`${config.hemocioneIdApiUrl}/internal/facts`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-secret": config.hemocioneIdFactsSecret,
+      },
+      body: JSON.stringify({ ...fact, sourceService: "hemocione-digital-event" }),
+    });
+    if (!response.ok) {
+      console.error(
+        `[gamification] hemocione-id rejected fact push: ${response.status}`,
+      );
+    }
+  } catch (error) {
+    console.error("[gamification] failed to push fact to hemocione-id", error);
+  }
+}

--- a/server/services/queueParticipants.ts
+++ b/server/services/queueParticipants.ts
@@ -2,6 +2,8 @@ import type { Types } from "mongoose";
 import { inngest } from "../inngest/client";
 import { QueueParticipant } from "../models/queueParticipant";
 import { upsertFBDataOnLead } from "./digitalStand";
+import { pushAttendanceConfirmedFacts } from "./attendanceFacts";
+import { runAsync } from "~/server/utils/runAsync";
 import { completePhone } from "~/utils/completePhone";
 
 export const getUserQueueParticipations = async (data: {
@@ -194,6 +196,8 @@ export async function callQueueParticipants(
   } catch (e) {
     console.error(e);
   }
+
+  runAsync(pushAttendanceConfirmedFacts(participantIds, queueId));
 }
 
 interface CreateQueueParticipant {

--- a/server/utils/isUuid.ts
+++ b/server/utils/isUuid.ts
@@ -1,0 +1,5 @@
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isUuid(value: string): boolean {
+  return UUID_REGEX.test(value);
+}

--- a/stores/user.ts
+++ b/stores/user.ts
@@ -121,7 +121,12 @@ export const useUserStore = defineStore("user", {
         this.subscriptions.set(eventSlug, subscription);
         return subscription;
       } catch (err: any) {
-        if (err?.data?.statusCode === 404) {
+        const statusCode = err?.data?.statusCode ?? err?.statusCode;
+
+        // 404 = sem subscription; 401 = sem token ou token inválido/expirado.
+        // Em ambos os casos tratamos como "não inscrito / deslogado" e seguimos
+        // sem subscription, em vez de propagar o erro e travar a página.
+        if (statusCode === 404 || statusCode === 401) {
           return null;
         }
 


### PR DESCRIPTION
## O que vai pra produção

Duas features que já passaram por `develop`, testadas e mergeadas separadamente:

### Vínculo evento ↔ banco de sangue/instituição (#47)
- `Event` ganha `bloodBanksLocationId`/`institutionId` opcionais (referência a registros do hemocione-id).
- Validação de formato UUID em `POST /api/v1/event` e `PUT /api/v1/event/[eventSlug]`.
- **Smoke test em preview**: criei um evento com os dois campos, confirmei o round-trip via GET, e confirmei rejeição 422 com id mal formado. Evento de teste já removido do banco dev.
- PRs irmãos: `Hemocione/hemocione-id#36` (endpoints de cadastro) e `Hemocione/hemocione-mcp#8` (tools do MCP).

### Gamification facts (#46, de outro agente trabalhando em paralelo em `develop`)
- Endpoint de fatos de gamificação (`event.attendance_confirmed`) pro hemocione-id.
- Não fiz esse trabalho — está em `develop` porque os dois fluxos compartilham a mesma branch de integração. Sinalizando aqui pra quem revisar não estranhar o escopo do diff.

## Test plan

- [x] `tsc --noEmit` sem erros novos na minha parte
- [x] Smoke test manual em preview (vínculo evento↔banco/instituição)
- [ ] Revisão de quem acompanhou a feature de gamification

🤖 Generated with [Claude Code](https://claude.com/claude-code)